### PR TITLE
Multiline argument required to use SoS and EoS identifiers in text block

### DIFF
--- a/pyapa/pyapa.py
+++ b/pyapa/pyapa.py
@@ -118,8 +118,9 @@ class ApaCheck:
     # patterns to be exempted
     url = re.compile(r"(http|ftp|file|https)://([\w_-]+(?:(?:\.[\w_-]+)+))"
                      + r"([\w.\b]*[\w\b])")
-    email = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
-
+    # Needs multiline in order to incorporate SoS (^) and EoS ($) in a text block
+    email = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", re.MULTILINE)
+    
     # init ApaCheck object with an optional context length
     def __init__(self):
         self.Matches = []


### PR DESCRIPTION
Changes Email regex to use multiline command as otherwise the Start of String (^) and End of String ($) fail to work in a text-block. Previously reported a stopspace-error on mail@krourke.org in the test.txt file.