### PR TITLE
Multiple authors + various 

### DIFF
--- a/pyapa/pyapa.py
+++ b/pyapa/pyapa.py
@@ -36,14 +36,14 @@ class ApaMatch:
             print("Match from " + str(self.start) + " to " + str(self.end)
                   + " for:")
             if self.target:
-                print("Target: " + self.target)
+                print("Target: " + self.target.strip())
         if self.feedback:
-            print("Feedback: " + self.feedback)
+            print("Feedback: " + self.feedback.strip())
         if self.see:
             print("See: " + self.see)
         if self.suggestions:
             for s in self.suggestions:
-                print("Suggestion: " + s)
+                print("Suggestion: " + s.strip())
 
     def sprint(self):
         string = ''

--- a/pyapa/pyapa.py
+++ b/pyapa/pyapa.py
@@ -118,8 +118,9 @@ class ApaCheck:
     # patterns to be exempted
     url = re.compile(r"(http|ftp|file|https)://([\w_-]+(?:(?:\.[\w_-]+)+))"
                      + r"([\w.\b]*[\w\b])")
-    email = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
-
+    # Needs multiline in order to incorporate SoS (^) and EoS ($) in a text block
+    email = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", re.MULTILINE)
+    
     # init ApaCheck object with an optional context length
     def __init__(self):
         self.Matches = []


### PR DESCRIPTION
A few edits here (see the individual commits).

For redundancy:

1) Strips printing output in adamatch obejcts.
2) Simplifies the YEAR pattern \d\d\d\d to \d{4}. Could be something like [12]\d{3} instead.
3) Uses the YEAR pattern in other patterns
4) Fixes and-in-brackets (as you've started on)
5) Implements ampersand-in-text
6) Removes refdatedot check as it seems incorrect (requires period after date reference)
7) Uses for-each rather than for-loops (much simpler and removes ten matchList[i] lookups)


I tried to implement lookbehind rather than the tedious patterns, that match everything in their wake, but doing so I lost the context and was unable to provide useful suggestions (e.g. looking for & rather than capturing [\w\s]+\s&\s+[\w\s]+ you could just look for (?<=&).
